### PR TITLE
Disable and enable foreign key while inserting encounter_type

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -231,11 +231,13 @@
     </changeSet>
     
     <changeSet author="Toyeeb" id="20042021104930" runOnChange="true">
+        <sql>SET FOREIGN_KEY_CHECKS=0;</sql>
         <sqlFile path="forms/forms/encounter_type.sql"
                  stripComments="true"
                  splitStatements="true"
                  encoding="UTF-8"
-                 endDelimiter=";"/>     
+                 endDelimiter=";"/> 
+        <sql>SET FOREIGN_KEY_CHECKS=1;</sql>     
     </changeSet>        
     
     <changeSet id="20042021105430" author="Toyeeb" runOnChange="true">


### PR DESCRIPTION
Compile the consolidation and noticed an error from the changeset below;

liquibase: Change Set liquibase.xml::20042021104930::Toyeeb
Cannot delete or update a parent row: a foreign key constraint fails

Disabling foreign key before insert and enabling it after insert was the proposed solution



