### PR TITLE
Fix: Viral Load Result Loss in Edit Mode (Lab Form) & Updated “Gender” to “Sex” on Recency Form

### DIFF
--- a/omod/src/main/webapp/resources/poc/pocforms/LaboratoryOrderAndResultForm.html
+++ b/omod/src/main/webapp/resources/poc/pocforms/LaboratoryOrderAndResultForm.html
@@ -847,7 +847,6 @@
 
         var $ = jQuery;
         $(document).ready(function(){
-        getField('viralLoadResultTest.value')[0].disabled = 'disabled';
         });
         jQuery(function() {
         getField('AlphanumericViralLoadResult.value').change(function() {

--- a/omod/src/main/webapp/resources/poc/pocforms/RecencyForm.html
+++ b/omod/src/main/webapp/resources/poc/pocforms/RecencyForm.html
@@ -1874,7 +1874,7 @@
                                 <td class="alnleft_f">
                                     <obs conceptId="166920" id="age_partner_obs" name="age_partner_obs" />
                                 </td>
-                                <td class="alnleft_f" id="gender_partner">Gender</td>
+                                <td class="alnleft_f" id="gender_partner">Sex</td>
 
                                 <td class="alnleft_f">
                                     <obs answerConceptIds="165184,165185" answerLabels="Male,Female" conceptId="165857" id="gender_partner_obs" />
@@ -2137,7 +2137,7 @@
                                 <td class="alnleft_f">
                                     <obs conceptId="166920" id="age_partner_obs" name="age_partner_obs" />
                                 </td>
-                                <td class="alnleft_f" id="gender_partner">Gender</td>
+                                <td class="alnleft_f" id="gender_partner">Sex</td>
 
                                 <td class="alnleft_f">
                                     <obs answerConceptIds="165184,165185" answerLabels="Male,Female" conceptId="165857" id="gender_partner_obs" />
@@ -2402,7 +2402,7 @@
                                 <td class="alnleft_f">
                                     <obs conceptId="166920" id="age_partner_obs" name="age_partner_obs" />
                                 </td>
-                                <td class="alnleft_f" id="gender_partner">Gender</td>
+                                <td class="alnleft_f" id="gender_partner">Sex</td>
 
                                 <td class="alnleft_f">
                                     <obs answerConceptIds="165184,165185" answerLabels="Male,Female" conceptId="165857" id="gender_partner_obs" />
@@ -2665,7 +2665,7 @@
                                 <td class="alnleft_f">
                                     <obs conceptId="166920" id="age_partner_obs" name="age_partner_obs" />
                                 </td>
-                                <td class="alnleft_f" id="gender_partner">Gender</td>
+                                <td class="alnleft_f" id="gender_partner">Sex</td>
 
                                 <td class="alnleft_f">
                                     <obs answerConceptIds="165184,165185" answerLabels="Male,Female" conceptId="165857" id="gender_partner_obs" />
@@ -2928,7 +2928,7 @@
                                 <td class="alnleft_f">
                                     <obs conceptId="166920" id="age_partner_obs" name="age_partner_obs" />
                                 </td>
-                                <td class="alnleft_f" id="gender_partner">Gender</td>
+                                <td class="alnleft_f" id="gender_partner">Sex</td>
 
                                 <td class="alnleft_f">
                                     <obs answerConceptIds="165184,165185" answerLabels="Male,Female" conceptId="165857" id="gender_partner_obs" />
@@ -3193,7 +3193,7 @@
                                 <td class="alnleft_f">
                                     <obs conceptId="166920" id="age_partner_obs" name="age_partner_obs" />
                                 </td>
-                                <td class="alnleft_f" id="gender_partner">Gender</td>
+                                <td class="alnleft_f" id="gender_partner">Sex</td>
 
                                 <td class="alnleft_f">
                                     <obs answerConceptIds="165184,165185" answerLabels="Male,Female" conceptId="165857" id="gender_partner_obs" />
@@ -3455,7 +3455,7 @@
                                 <td class="alnleft_f">
                                     <obs conceptId="166920" id="age_partner_obs" name="age_partner_obs" />
                                 </td>
-                                <td class="alnleft_f" id="gender_partner">Gender</td>
+                                <td class="alnleft_f" id="gender_partner">Sex</td>
 
                                 <td class="alnleft_f">
                                     <obs answerConceptIds="165184,165185" answerLabels="Male,Female" conceptId="165857" id="gender_partner_obs" />


### PR DESCRIPTION
- Resolved an issue where the viral load result disappeared when a lab order form was opened and saved in edit mode, even without any modifications.

- Updated all instances of the “Gender” label to “Sex” on the Recency form to align with current program standards.